### PR TITLE
Change Carpentries branding to IDEAS

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,7 +8,9 @@
 # lc: Library Carpentry
 # cp: Carpentries (to use for instructor training for instance)
 # incubator: The Carpentries Incubator
-carpentry: 'incubator'
+carpentry: 'IDEAS'
+varnish: 'HealthBioscienceIDEAS/varnish@IDEAS'
+sandpaper: 'HealthBioscienceIDEAS/sandpaper@IDEAS'
 
 # Overall title for pages.
 title: 'Lesson Title'
@@ -58,17 +60,17 @@ contact: 'team@carpentries.org'
 # - another-learner.md
 
 # Order of episodes in your lesson
-episodes: 
+episodes:
 - introduction.Rmd
 
 # Information for Learners
-learners: 
+learners:
 
 # Information for Instructors
-instructors: 
+instructors:
 
 # Learner Profiles
-profiles: 
+profiles:
 
 # Customisation ---------------------------------------------
 #


### PR DESCRIPTION
Fixes https://github.com/HealthBioscienceIDEAS/microscopy-novice/issues/2

This PR updates the lesson to use forked versions of [varnish](https://github.com/HealthBioscienceIDEAS/varnish) and [sandpaper](https://github.com/HealthBioscienceIDEAS/sandpaper)
These include the IDEAS logos and colour scheme (as in screenshots below). To preview the full website locally, you can clone the repo and use ```sandpaper::build_site()``` in RStudio, once the forked versions of sandpaper and varnish are installed. Which can be done by running the following commands in R:

```r
## Install remotes package
install.packages("remotes")

## Install sandpaper and varnish from the IDEAS forks
remotes::install_github("HealthBioscienceIDEAS/sandpaper", dependencies = TRUE)
remotes::install_github("HealthBioscienceIDEAS/varnish", dependencies = TRUE)
```

Then to build the lesson locally, from within the `microscopy-novice` directory, run

```r
sandpaper::build_site()
```

That _should_ open the built home page in a browser window automatically, but if not, you can find the built HTML files in the `site/` directory.

![Screenshot 2023-11-13 165206](https://github.com/HealthBioscienceIDEAS/microscopy-novice/assets/24316371/c4349960-d36b-43bd-bebf-658ea7dd8f60)
