### PR TITLE
Add lesson title

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -11,7 +11,7 @@
 carpentry: 'IDEAS'
 
 # Overall title for pages.
-title: 'Lesson Title'
+title: 'Image Analysis for Microscopy'
 
 # Date the lesson was created (YYYY-MM-DD, this is empty by default)
 created: '2023-10-26'
@@ -27,7 +27,7 @@ life_cycle: 'pre-alpha'
 license: 'CC-BY 4.0'
 
 # Link to the source repository for this lesson
-source: 'https://example.com/FIXME-template-source'
+source: 'https://github.com/HealthBioscienceIDEAS/microscopy-novice'
 
 # Default branch of your lesson
 branch: 'main'
@@ -58,7 +58,7 @@ contact: 'team@carpentries.org'
 # - another-learner.md
 
 # Order of episodes in your lesson
-episodes: 
+episodes:
 - imaging-software.md
 - what-is-an-image.md
 - image-display.md
@@ -70,13 +70,13 @@ episodes:
 - filters-and-thresholding.md
 
 # Information for Learners
-learners: 
+learners:
 
 # Information for Instructors
-instructors: 
+instructors:
 
 # Learner Profiles
-profiles: 
+profiles:
 
 # Customisation ---------------------------------------------
 #


### PR DESCRIPTION
Closes https://github.com/HealthBioscienceIDEAS/microscopy-novice/issues/52

This PR adds an overall lesson title. I went with 'Image Analysis for Microscopy', as longer titles were causing overlap between the lesson title text and other elements in the header. Let me know if you'd like to change this to something else.