### PR TITLE
Switch to `carpentries/sandpaper` instead of our own fork

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -88,4 +88,3 @@ profiles:
 
 
 varnish: HealthBioscienceIDEAS/varnish@IDEAS
-sandpaper: HealthBioscienceIDEAS/sandpaper@IDEAS


### PR DESCRIPTION
Following carpentries/sandpaper#585, we can now use a custom lesson
format without requiring our own `sandpaper` fork.

Fixes #63.
