### PR TITLE
Fix napari icon links

### DIFF
--- a/episodes/filetypes-and-metadata.md
+++ b/episodes/filetypes-and-metadata.md
@@ -439,7 +439,7 @@ Which is smallest?
 
 - Open all four images in Napari. Zoom in very close to a bright nucleus, and 
 try showing / hiding different layers with the ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/visibility.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/visibility.svg
 ){alt="A screenshot of Napari's eye button" height='30px'} icon. 
 How do they differ? How does each compare to timepoint 30 of the original 
 '00001_01.ome' image?

--- a/episodes/filters-and-thresholding.md
+++ b/episodes/filters-and-thresholding.md
@@ -57,7 +57,7 @@ If you don't have Napari's 'Cells (3D + 2Ch)' image open, then open it with:
 
 Make sure you only have 'nuclei' in the layer list. Select any additional 
 layers, then click the ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/delete.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/delete.svg
 ){alt="A screenshot of Napari's delete layer button" height='30px'} icon to 
 remove them. Also, select the nuclei layer (should be highlighted in blue), and 
 change its colormap from 'green' to 'gray' in the layer controls.
@@ -130,7 +130,7 @@ You should see a mask appear that highlights the nuclei in brown. If we set the
 nuclei contrast limits back to normal (select 'nuclei' in the layer list, then 
 drag the left contrast limits node back to zero), then toggle on/off the mask 
 or nuclei layers with the ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/visibility.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/visibility.svg
 ){alt="A screenshot of Napari's eye button" height='30px'} icon, you should see 
 that the brown areas match the nucleus boundaries reasonably well. They aren't 
 perfect though! The brown regions have a speckled appearance where some regions 
@@ -303,7 +303,7 @@ Let's open the cells image in Napari again:
 
 As before, make sure you only have 'nuclei' in the layer list. Select any 
 additional layers, then click the ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/delete.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/delete.svg
 ){alt="A screenshot of Napari's delete layer button" height='30px'} icon to 
 remove them. Also, select the nuclei layer (should be highlighted in blue), and 
 change its colormap from 'green' to 'gray' in the layer controls.
@@ -527,11 +527,11 @@ shrink in size. Increasing the 'radius' of the filter enhances the effect.
 First, let's clean up our layer list. Make sure you only have the 'nuclei' and 
 'Result of gaussian_blur' layers in the layer list - select any others and 
 remove them by clicking the ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/delete.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/delete.svg
 ){alt="A screenshot of Napari's delete layer button" height='30px'} icon. Also, 
 close all filter settings panels on the right side of Napari (apart from the 
 gaussian settings) by clicking the tiny ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/visibility_off.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/visibility_off.svg
 ){alt="A screenshot of Napari's hide button" height='20px'} icon at their top 
 left corner.
 
@@ -585,11 +585,11 @@ processing, and it's good to keep an eye out for when this is required!
 
 Let's return to thresholding our image. Close the gaussian panel by clicking the 
 tiny ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/visibility_off.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/visibility_off.svg
 ){alt="A screenshot of Napari's hide button" height='20px'} icon at its top left 
 corner. Then select the 'blurred_mask' in the layer list and remove it by 
 clicking the ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/delete.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/delete.svg
 ){alt="A screenshot of Napari's delete layer button" height='30px'} icon. 
 Finally, open the `napari-matplotlib` histogram again with:  
 `Plugins > napari Matplotlib > Histogram`
@@ -655,7 +655,7 @@ clear that some areas are still missed or incorrectly labelled.
 First, let's clean up our layer list again. Make sure you only have the 
 'nuclei', 'mask', 'blurred_mask' and 'Result of gaussian_blur' layers in the 
 layer list - select any others and remove them by clicking the ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/delete.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/delete.svg
 ){alt="A screenshot of Napari's delete layer button" height='30px'} icon. Then, 
 if you still have the `napari-matplotlib` histogram open, close it by clicking 
 the tiny `x` icon in the top left corner.
@@ -682,10 +682,10 @@ name in the layer list - for example, rename 'mask' to 'manual_mask',
 'blurred_mask' to 'manual_blurred_mask', and 'Result of threshold_otsu' to 
 'otsu_blurred_mask'. Recall that you can change the colour of a mask by clicking 
 the ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/shuffle.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/shuffle.svg
 ){alt="A screenshot of Napari's shuffle button" height='30px'} icon in the top 
 row of the layer controls. By toggling on/off the relevant ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/visibility.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/visibility.svg
 ){alt="A screenshot of Napari's eye button" height='30px'} icons, you should see 
 that Otsu chooses a slightly different threshold than we did in our 
 'manual_blurred_mask', labelling slightly smaller regions as nuclei in the final 
@@ -727,7 +727,7 @@ How do they compare to standard Otsu thresholding?
 `Tools > Segmentation / binarization > Threshold (Otsu et al 1979, scikit-image, nsbatwm)`
 
 Recall that you can change the colour of a mask by clicking the ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/shuffle.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/shuffle.svg
 ){alt="A screenshot of Napari's shuffle button" height='30px'} icon in the top 
 row of the layer controls.
 
@@ -787,10 +787,10 @@ the 'Napari assistant'.
 
 First, let's clean up our layer list again. Make sure you only have the 'nuclei' 
 layer in the layer list - select any others and remove them by clicking the ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/delete.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/delete.svg
 ){alt="A screenshot of Napari's delete layer button" height='30px'} icon. Also, 
 close all settings panels on the right side of Napari by clicking the tiny ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/visibility_off.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/visibility_off.svg
 ){alt="A screenshot of Napari's hide button" height='20px'} icon at their top 
 left corner.
 

--- a/episodes/image-display.md
+++ b/episodes/image-display.md
@@ -325,7 +325,7 @@ limit will remove any low intensity parts of the image from the display.
 ## Adjusting contrast
 
 Open the Napari console with the ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/console.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/console.svg
 ){alt="A screenshot of Napari's console button" height='30px'}
 button and copy and paste the code below:
 ```

--- a/episodes/imaging-software.md
+++ b/episodes/imaging-software.md
@@ -314,16 +314,16 @@ The viewer buttons (the row of buttons at the bottom left of Napari) control
 various aspects of the Napari viewer:
 
 ### Console ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/console.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/console.svg
 ){alt="A screenshot of Napari's console button" height='30px'}
 
 This button opens Napari's built-in python console - we'll use the console more
 in later episodes.
 
 ### 2D/3D ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/2D.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/2D.svg
 ){alt="A screenshot of Napari's 2D button" height='25px'}  / ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/3D.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/3D.svg
 ){alt="A screenshot of Napari's 3D button" height='25px'}
 
 This switches the canvas between 2D and 3D display. Try switching to the 3D view 
@@ -339,7 +339,7 @@ Zoom - Scroll in/out
 ```
 
 ### Roll dimensions ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/roll.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/roll.svg
 ){alt="A screenshot of Napari's roll dimensions button" height='25px'} 
 
 This changes which image dimensions are displayed in the viewer. For example, 
@@ -352,7 +352,7 @@ will bring us back to the original orientation.
 with different axes being visualised"}
 
 ### Transpose dimensions ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/transpose.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/transpose.svg
 ){alt="A screenshot of Napari's transpose dimensions button" height='25px'}
 
 This button swaps the two currently displayed dimensions. Again trying this for 
@@ -363,7 +363,7 @@ again brings us back to the original orientation.
 with dimensions swapped"}
 
 ### Grid ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/grid.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/canvas-grid-view.svg
 ){alt="A screenshot of Napari's grid button" height='25px'}
 
 This button displays all image layers in a grid (+ any additional layer types,
@@ -372,7 +372,7 @@ image, we see the nuclei (green) displayed next to the cell membranes (purple),
 rather than on top of each other.
 
 ### Home ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/home.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/home.svg
 ){alt="A screenshot of Napari's home button" height='25px'}
 
 This button brings the canvas back to its default view. This is useful if you 
@@ -475,7 +475,7 @@ supported by Napari. The layer buttons allow us to add additional layers of
 these new types:
 
 ### Points ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/new_points.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/new_points.svg
 ){alt="A screenshot of Napari's point layer button" height='30px'}
 
 This button creates a new 
@@ -483,7 +483,7 @@ This button creates a new
 be used to mark specific locations in an image.
 
 ### Shapes ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/new_shapes.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/new_shapes.svg
 ){alt="A screenshot of Napari's shape layer button" height='30px'} 
 
 This button creates a new 
@@ -491,7 +491,7 @@ This button creates a new
 be used to mark regions of interest e.g. with rectangles, ellipses or lines.
 
 ### Labels ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/new_labels.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/new_labels.svg
 ){alt="A screenshot of Napari's labels layer button" height='30px'}
 
 This button creates a new 
@@ -500,7 +500,7 @@ usually used to label specific regions in an image e.g. to label individual
 nuclei.
 
 ### Remove layer ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/delete.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/delete.svg
 ){alt="A screenshot of Napari's delete layer button" height='30px'}  
 
 This button removes the currently selected layer (highlighted in blue) from the 
@@ -536,11 +536,11 @@ Add points and adjust settings to give the result below:
 :::::::::::::::::::::::: solution 
  
 - Click the 'add points' button ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/add.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/add.svg
 ){alt="Screenshot of Napari's add points button" height='30px'}
 - Click on nuclei to add points on top of them
 - Click the 'select points' button ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/select.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/select.svg
 ){alt="Screenshot of Napari's select points button" height='30px'}
 - Click on the point over the dividing nucleus
 - Increase the point size slider

--- a/episodes/instance-segmentation-and-measurements.md
+++ b/episodes/instance-segmentation-and-measurements.md
@@ -64,7 +64,7 @@ First, let's open one of Napari's sample images with:
 `File > Open Sample > napari builtins > Cells (3D + 2Ch)`
 
 Open Napari's console by pressing the ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/console.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/console.svg
 ){alt="A screenshot of Napari's console button" height='30px'} button,
 then copy and paste the code below.
 
@@ -270,7 +270,7 @@ they are adjacent to another segmented pixel in any of the three dimensions
 
 You may remember from our [first lesson](imaging-software.md#d3d) that
 we can change to 3D view mode by pressing the ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/2D.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/2D.svg
 ){alt="Napari's 2D/3D toggle" height='30px'} button.
 Try it now.
 

--- a/episodes/multi-dimensional-images.md
+++ b/episodes/multi-dimensional-images.md
@@ -83,7 +83,7 @@ for the y and x axes). These comments won't appear in the output in your console
 ## 3D
 
 Let's remove the mitosis image by clicking the remove layer button ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/delete.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/delete.svg
 ){alt="A screenshot of Napari's delete layer button" height='30px'} at the top 
 right of the layer list. Then, let's open a new 3D image:  
 `File > Open Sample > napari builtins > Brain (3D)`
@@ -292,7 +292,7 @@ depend on your image and preference. Some pros and cons are shown below:
 a time)
 
 2. Channels can be easily shown/hidden with the ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/visibility.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/visibility.svg
 ){alt="A screenshot of Napari's eye button" height='20px'} icons
 
 3. Display settings like contrast limits and colormaps can be controlled 
@@ -338,11 +338,11 @@ This image is a 2D time series (tyx) of some human cells undergoing mitosis. The
 slider at the bottom now moves through time, rather than z or channels. Try 
 moving the slider from left to right -  you should see some nuclei divide and 
 the total number of nuclei increase. You can also press the small ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/right_arrow.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/right_arrow.svg
 ){alt="A screenshot of Napari's play button" height='20px'} icon at the 
 left side of the slider to automatically move along it. The icon will change 
 into a ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/square.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/square.svg
 ){alt="A screenshot of Napari's stop button" height='25px'}- pressing this will 
 stop the movement.
 
@@ -417,7 +417,7 @@ This is a fluorescence microscopy image of mouse kidney tissue.
 
 2. What do each of those dimensions represent? (e.g. t, c, z, y, x) **Hint:** 
 try using the roll dimensions button ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/roll.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/roll.svg
 ){alt="A screenshot of Napari's roll dimensions button" height='25px'} to view 
 different combinations of axes.
 
@@ -451,7 +451,7 @@ image.shape
 
 ### 2
 If we press the roll dimensions button ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/roll.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/roll.svg
 ){alt="A screenshot of Napari's roll dimensions button" height='25px'} once, we 
 can see an image of various cells and nuclei. Moving the slider labelled '0' 
 seems to move up and down in this image (i.e. the z axis), while moving the 
@@ -511,7 +511,7 @@ image layer and select:
 
 This shows the red, green and blue channels as separate image layers. Try 
 inspecting each one individually by clicking the ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/visibility.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/visibility.svg
 ){alt="A screenshot of Napari's eye button" height='30px'} icons to hide the 
 other layers.
 

--- a/episodes/quality-control-and-manual-segmentation.md
+++ b/episodes/quality-control-and-manual-segmentation.md
@@ -151,7 +151,7 @@ to each other, using some simple examples.
 
 First, let's take a quick look at a rough semantic segmentation. Open Napari's 
 console by pressing the ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/console.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/console.svg
 ){alt="A screenshot of Napari's console button" height='30px'} button, then copy 
 and paste the code below. Don't worry about the details of what's happening in 
 the code - we'll look at some of these concepts like gaussian blur and otsu 
@@ -174,7 +174,7 @@ segmentation of nuclei in Napari"}
 
 You should see an image appear that highlights the nuclei in brown. Try toggling 
 the 'semantic_seg' layer on and off multiple times, by clicking the ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/visibility.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/visibility.svg
 ){alt="A screenshot of Napari's eye button" height='30px'} icon next to its name 
 in the layer list. You should see that the brown areas match the nucleus 
 boundaries reasonably well.
@@ -208,11 +208,11 @@ segmentation of nuclei in Napari"}
 
 You should see an image appear that highlights nuclei in different colours. 
 Let's hide the 'semantic_seg' layer by clicking the ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/visibility.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/visibility.svg
 ){alt="A screenshot of Napari's eye button" height='30px'} icon next to its name 
 in Napari's layer list. Then try toggling the 'instance_seg' layer on and off 
 multiple times, by clicking the corresponding ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/visibility.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/visibility.svg
 ){alt="A screenshot of Napari's eye button" height='30px'} icon. You should see 
 that the coloured areas match most of the nucleus boundaries reasonably well, 
 although there are some areas that are less well labelled.
@@ -235,11 +235,11 @@ use?
 First, let's focus on the 'semantic_seg' layer we created earlier:
 
 - Click the ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/visibility.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/visibility.svg
 ){alt="A screenshot of Napari's eye button" height='30px'} icon next to 
 'semantic_seg' in the layer list to make it visible. 
 - Click the ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/visibility.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/visibility.svg
 ){alt="A screenshot of Napari's eye button" height='30px'} icon next to 
 'instance_seg' in the layer list to hide it.
 - Make sure the 'semantic_seg' layer is selected in the layer list. It should be 
@@ -291,11 +291,11 @@ values of 0, 1, 2 and 3.
 Let's take a look at the pixel values in the instance segmentation:
 
 - Click the ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/visibility.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/visibility.svg
 ){alt="A screenshot of Napari's eye button" height='30px'} icon next to 
 'instance_seg' in the layer list to make it visible. 
 - Click the ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/visibility.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/visibility.svg
 ){alt="A screenshot of Napari's eye button" height='30px'} icon next to 
 'semantic_seg' in the layer list to hide it.
 - Make sure the 'instance_seg' layer is selected in the layer list. It should be 
@@ -459,12 +459,12 @@ the two segmentation layers:
 
 - Click on 'instance_seg', then <kbd>shift</kbd> + click 'semantic_seg'
 - Click the ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/delete.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/delete.svg
 ){alt="A screenshot of Napari's delete layer button" height='30px'} icon to 
 remove these layers.
 
 Then click on the ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/new_labels.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/new_labels.svg
 ){alt="A screenshot of Napari's labels layer button" height='30px'} icon (at the 
 top of the layer list) to create a new `Labels` layer.
 
@@ -479,17 +479,17 @@ labels layers in Napari"}
 
 Let's start by painting an individual nucleus. Select the paintbrush by clicking 
 the ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/paint.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/paint.svg
 ){alt="A screenshot of Napari's paintbrush button" height='30px'} icon in the 
 top row of the layer controls. Then click and drag across the image to label 
 pixels. You can change the size of the brush using the 'brush size' slider in 
 the layer controls. To return to normal movement, you can click the ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/pan_arrows.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/pan_arrows.svg
 ){alt="A screenshot of Napari's pan arrows button" height='30px'} icon in the 
 top row of the layer controls, or hold down spacebar to activate it temporarily 
 (this is useful if you want to pan slightly while painting). To remove painted 
 areas, you can activate the label eraser by clicking the ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/erase.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/erase.svg
 ){alt="A screenshot of Napari's erase button" height='30px'} icon.
 
 ![](fig/single-painted-nucleus.png){alt="A screenshot of a single manually 
@@ -516,7 +516,7 @@ display. The colormap for `Labels` layers will assign random colours to each
 pixel value, trying to ensure that nearby values (like 2 vs 3) are given 
 dissimilar colours. This helps to make it easier to distinguish different 
 labels. You can shuffle the colours used by clicking the ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/shuffle.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/shuffle.svg
 ){alt="A screenshot of Napari's shuffle button" height='30px'} icon in the top 
 row of the layer controls. Note that the pixel value of 0 will always be shown 
 as transparent - this is because it is usually used to represent the background.
@@ -529,10 +529,10 @@ Try labelling more individual nuclei in this image, making sure each gets its
 own pixel value (label). Investigate the other settings in the layer controls:
 
 - What does the ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/fill.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/fill.svg
 ){alt="A screenshot of Napari's fill button" height='30px'} icon do?
 - What does the ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/picker.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/picker.svg
 ){alt="A screenshot of Napari's picker button" height='30px'} icon do?
 - What does the 'contour' setting control?
 - What does the 'n edit dim' setting control?
@@ -551,7 +551,7 @@ undo your last action. If you need to re-do it use
 ### Solution
 
 ###  ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/fill.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/fill.svg
 ){alt="A screenshot of Napari's fill button" height='30px'} icon
 
 This icon activates the 'fill bucket'. It will fill whatever label you click on 
@@ -562,7 +562,7 @@ in [Napari's documentation
 ](https://napari.org/stable/howtos/layers/labels.html#using-the-fill-bucket)
 
 ### ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/picker.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/picker.svg
 ){alt="A screenshot of Napari's picker button" height='30px'} icon
 
 This icon activates the 'colour picker'. This allows you to click on a pixel in 

--- a/episodes/what-is-an-image.md
+++ b/episodes/what-is-an-image.md
@@ -38,7 +38,7 @@ episode. Then we can open a new sample image:
 bottom layer. This should highlight all layers in blue.
 
 - Press the remove layer button ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/delete.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/delete.svg
 ){alt="A screenshot of Napari's delete layer button" height='30px'} 
 
 - Go to the top menu-bar of Napari and select:  
@@ -71,7 +71,7 @@ specific values - but how is an image really represented in the computer? Let's
 dig deeper into Napari's `Image` layers...
 
 First, open Napari's built-in Python console by pressing the console button ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/console.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/console.svg
 ){alt="A screenshot of Napari's console button" height='30px'}. 
 Note this can take a few seconds to open, so give it some time:
 
@@ -87,7 +87,7 @@ decreased with <kbd>Ctrl</kbd> and <kbd>-</kbd> together.
 
 Note that you can also pop the console out into its own window by clicking the 
 small ![](
-https://raw.githubusercontent.com/napari/napari/main/napari/resources/icons/pop_out.svg
+https://raw.githubusercontent.com/napari/napari/main/src/napari/resources/icons/pop_out.svg
 ){alt="A screenshot of Napari's float panel button" height='30px'} 
 icon on the left side.
 


### PR DESCRIPTION
This PR fixes links to napari icons - e.g. those in the [viewer buttons](https://healthbioscienceideas.github.io/microscopy-novice/imaging-software.html#viewer-buttons) section. Napari modified its repository structure to include a `src` dir, hence the broken links.