### PR TITLE
Update exercise to mention OverflowError

### DIFF
--- a/episodes/what-is-an-image.md
+++ b/episodes/what-is-an-image.md
@@ -394,9 +394,10 @@ value. For example, storing 1000 in a `uint8` image may result in 255 being
 stored instead (the max value)
 
 - Overflow: For NumPy arrays, values outside the valid range may be 
-'wrapped around' to give the new result. For example, storing 256 in a `uint8` 
-image (max 255) would give 0, 257 would give 1 and so on... Otherwise, you 
-may see an `OverflowError` being thrown.
+'wrapped around' or create an `OverflowError`, depending on what version of 
+NumPy is installed. Older versions of NumPy may wrap the values around, so 
+storing 256 in a `uint8` image (max 255) would give 0, 257 would give 1 and so 
+on... Newer versions of NumPy will raise an `OverflowError`.
 
 Clipping and overflow result in data loss - you can't get the original values 
 back! So it's always good to keep the data type in mind when doing image 


### PR DESCRIPTION
Closes https://github.com/HealthBioscienceIDEAS/microscopy-novice/issues/79

Newer `numpy` versions throw an `OverflowError` rather than silently 'wrapping around' the value. This updates the relevant episode text.