### PR TITLE
Add link checker

### DIFF
--- a/.github/workflows/links.yaml
+++ b/.github/workflows/links.yaml
@@ -40,8 +40,6 @@ jobs:
           # for user profiles that return 404 when tested in GitHub Actions, 
           # even though they work correctly when accessed via a browser.
 
-          # Exclude relative pages.
-
           args: "--verbose
             --exclude https://forum.image.sc/
             --exclude https://stackoverflow.com


### PR DESCRIPTION
**Why is this PR needed?**
The flag up broken links, that can for example happen when external sources (e.g. napari) re-arrange their folder structure (this is what happened in #73).  ⛓️‍💥

**What does this PR do?**
This PR adds a basic workflow to check for broken links with GitHub Actions similar to that used in the [UCL-ARC python-tooling repo](https://github.com/UCL-ARC/python-tooling).

_Triggers_
The link checker will run on:
- push to the main branch.
- opening/updating a PR
- every Sunday at midnight

_Exclusions_
The link checker excludes:
- a couple of links (including to the image.sc forum) that are known to return `403` from github runners.
- a couple of pages that are known to often be down but are still the right websites to link to.
- links containing '?q=user%3A' matching GitHub search queries that return 404 when tested in GitHub Actions even though they work correctly when accessed via a browser (leading to exclusion of e.g.  https://github.com/issues?q=user%3Adatacarpentry)

**How has this PR been checked?**
I checked the workflow by opening a PR to main on my fork and looking at the[ GitHub Actions link checker results](https://github.com/stellaprins/microscopy-novice/actions/runs/18967524783/job/54167321258).

Next I fixed broken links (#89) and checked whether the link checker passed successfully on the updated PR on my fork. See [here ](https://github.com/stellaprins/microscopy-novice/actions/runs/18970432034/job/54176700086?pr=3)for the link checker results after fixing broken links. 

**Linked issues**
Resolves #74

**Note**
This is a copy of #87 which could not be reopened because the changes were already added and subsequently removed from #88 