### PR TITLE
add note about possible error and fix for problems opening czi images

### DIFF
--- a/learners/setup.md
+++ b/learners/setup.md
@@ -238,6 +238,7 @@ you may see lots of text printed to the terminal as it downloads these extra
 files. This may take up to 5 minutes - so give it some time. This will only 
 happen once, and the `czi` image will open much faster next time.
 
+::::::::::::::::::::::::::::::::::::::::::: caution
 ### Potential error
 On some Windows systems `bioio-bioformats` dependencies prevent `czi` files 
 from opening in napari. If this is the case, napari may crash with the following 
@@ -252,7 +253,7 @@ pip uninstall bioio-bioformats
 ```
 
 Restart napari and try opening `Plate1-Blue-A-12-Scene-3-P3-F2-03.czi` again.
-
+:::::::::::::::::::::::::::::::::::::::::::
 
 ::::::::::::::::::::::::::
 ::::::::::::::::::: solution


### PR DESCRIPTION
**Why is this PR needed**
After following the setup instructions, napari crashed with the following error when I tried to open `Plate1-Blue-A-12-Scene-3-P3-F2-03.czi`.

```
13:43:06 : WARNING : MainThread : Attempted file (C:/Users/prins/Downloads/Plate1-Blue-A-12-Scene-3-P3-F2-03.czi) load with reader: <class 'bioio_bioformats.reader.Reader'> failed with error: bioformats  does not support the image: 'C:/Users/prins/Downloads/Plate1-Blue-A-12-Scene-3-P3-F2-03.czi'. Can't find org.jpype.jar support library
```

Kimberly and I did some trouble shooting, and could fix the issue.

@K-Meech 
> This dependency is coming from the bioio-bioformats reader (which is automatically installed by napari-bioio-reader). Specifically, it's a [dependency of ](https://github.com/scijava/scyjava)Scyjava that sets up the required java / maven dependencies.
> Looks like [there are some similar reports there](https://github.com/scijava/scyjava/issues/74), of it not working on particular windows systems.
> 
> We should probably add something about this to the installation instructions. An easier solution might be uninstalling bioio-bioformats as we don't use it.
> 
> I'd suggest putting it as an optional note in the check napari opens a czi image section (as it only appears to affect some windows systems and not others). Ideally we can keep bioio-bioformats for most people - as it supports the widest range of file formats!
> What do you think? You could add something like, if you see X error..., then run...

**What does this PR do**
Adds a warning box with description of the potential issue and the fix to **Check napari opens a czi image**  section.

See **Potential error** section
<img width="555" height="912" alt="image" src="https://github.com/user-attachments/assets/79159853-8cf1-4f36-af69-01ba91ce0685" />
