### PR TITLE
remove HealthBioscienceIDEAS/sandpaper installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,8 @@ To install these forks locally, run the following from within an R session:
 ## Install devtools
 install.packages("remotes")
 
-## Install sandpaper and varnish from the IDEAS forks
-## HealthBioscienceIDEAS/varnish is listed as a dependency of sandpaper, so will be installed as well
-remotes::install_github("HealthBioscienceIDEAS/sandpaper", dependencies = TRUE)
+## Install HealthBioscienceIDEAS/varnish 
+remotes::install_github("HealthBioscienceIDEAS/varnish", dependencies = TRUE)
 ```
 
 Then to build the lesson locally, from within the `microscopy-novice` directory, run


### PR DESCRIPTION
**Why is this PR needed**
I had issues building the lesson `html`s locally because the docs are out of date (see [comment ](https://github.com/HealthBioscienceIDEAS/microscopy-novice/pull/92#issuecomment-3479615546)on #92).

**What does this PR do**
Update instructions.

**Linked issues**
Resolves #91 