### PR TITLE
Expand readme and remove UCL-specific links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Image Analysis for Microscopy
+# Image Analysis with Napari for Microscopy
 
 A lesson teaching the fundamentals of analysing image data acquired via light microscopy experiments.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,24 @@
-# microscopy-novice
+# Image Analysis for Microscopy
 
-    This is the lesson repository for microscopy-novice
+A lesson teaching the fundamentals of analysing image data acquired via light microscopy experiments.
+
+## Lesson Content
+
+This lesson focuses on the use of [napari](https://napari.org/), a Python-based image viewer, for all image processing steps.
+It also covers the basics of how to design a light microscopy experiment and optimise acquisition settings for a given research question.
+
+## Contribution
+
+Contributions are very welcome - please make a suggestion or correct an error by [raising an issue](https://github.com/HealthBioscienceIDEAS/microscopy-novice/issues).
+
+See the [CONTRIBUTING.md file](CONTRIBUTING.md) for contribution guidelines.
+
+## Acknowledgements
+
+These lessons were initially developed as part of the [Health and Biosciences IDEAS](https://healthbioscienceideas.github.io/) project, which is a training initiative funded by [UKRI Innovation Scholars](https://www.ukri.org/opportunity/innovation-scholars-data-science-training-in-health-bioscience/) (MR/V03863X/1). 
+
+Continued support for this project is provided in part by the [UKRI Digital Research Skills Catalyst](https://digitalskillscatalyst.ac.uk/). 
+The Catalyst Project is funded by UKRI Digital Research Infrastructure Programme from October 2024 to March 2027. Project reference: UKRI/ST/B000299/1.
 
 ## Development
 
@@ -41,9 +59,8 @@ When you're happy, commit, push and open a PR on GitHub. This will trigger the
 [*sandpaper* PR validation and preview
 workflows](https://carpentries.github.io/sandpaper-docs/pull-request.html) to
 validate and preview the new content. Once the PR gets approved, merge it into
-`main` and wait for the [Build and
-Deploy](https://github.com/HealthBioscienceIDEAS/microscopy-novice/actions/workflows/sandpaper-main.yaml)
-action to complete, after which the updates should be visible on the
+`main` and wait for the github actions to complete, after which the updates 
+should be visible on the
 [website](https://healthbioscienceideas.github.io/microscopy-novice/)
 
 ### Building the lesson locally

--- a/config.yaml
+++ b/config.yaml
@@ -21,7 +21,7 @@ keywords: 'software, data, lesson, The Carpentries'
 
 # Life cycle stage of the lesson
 # possible values: pre-alpha, alpha, beta, stable
-life_cycle: 'pre-alpha'
+life_cycle: 'beta'
 
 # License of the lesson materials (recommended CC-BY 4.0)
 license: 'CC-BY 4.0'

--- a/episodes/additional-resources.md
+++ b/episodes/additional-resources.md
@@ -73,13 +73,15 @@ principles.
 
 
 ### Talks/seminars about image processing
-- [UCL Bioimage interest group](https://www.ucl.ac.uk/lmcb/ucl-biig)  
-Monthly talks (in person and online) about image analysis of biological images. 
-Open to all.
-
 - [Eurobioimaging virtual pub
 ](https://www.eurobioimaging.eu/about-us/virtual-pub)  
 Weekly online talks on various topics related to microscopy and image analysis. 
+Open to all.
+
+- [Global BioImage Analysts' Society (GloBIAS) seminar series](https://www.globias.org/activities/bia-seminar-series-2025-2026) Online talks on bio-image analysis. Open to all.
+
+- [UCL Bioimage interest group](https://www.ucl.ac.uk/science-technology-platforms/imaging/ucl-bioimage-interest-group)  
+Monthly talks (in person and online) about image analysis of biological images. 
 Open to all.
 
 ### Python

--- a/episodes/additional-resources.md
+++ b/episodes/additional-resources.md
@@ -78,7 +78,8 @@ principles.
 Weekly online talks on various topics related to microscopy and image analysis. 
 Open to all.
 
-- [Global BioImage Analysts' Society (GloBIAS) seminar series](https://www.globias.org/activities/bia-seminar-series-2025-2026) Online talks on bio-image analysis. Open to all.
+- [Global BioImage Analysts' Society (GloBIAS) seminar series](https://www.globias.org/activities/bia-seminar-series-2025-2026)  
+Online talks on bio-image analysis. Open to all.
 
 - [UCL Bioimage interest group](https://www.ucl.ac.uk/science-technology-platforms/imaging/ucl-bioimage-interest-group)  
 Monthly talks (in person and online) about image analysis of biological images. 

--- a/index.md
+++ b/index.md
@@ -17,9 +17,7 @@ work with light microscopy imaging data in their research projects.
 
 - No python experience is necessary or assumed, but you will get more out of the 
 course if you know some basics e.g. from the online [Software Carpentry 
-python course](https://swcarpentry.github.io/python-novice-inflammation/) or 
-[an in-person course at UCL
-](https://www.ucl.ac.uk/advanced-research-computing/education/training).
+python course](https://swcarpentry.github.io/python-novice-inflammation/).
 
 - Please bring a laptop (Windows, Mac or Linux) to the lesson. Before the start 
 of the course, please follow the [setup instructions](learners/setup.md) so 


### PR DESCRIPTION
In preparation for submitting this to the Carpentries incubator, I've made some minor changes:
- Expanded the readme with information about the lesson, and acknowledgement of original funding (the acknowledgements paragraph was provided by Dave Cash)
- Updated the [carpentries life cycle stage](https://docs.carpentries.org/resources/curriculum/lesson-life-cycle.html) to `beta` as recommended by Toby Hodges (one of the Carpentries team)
- As we want to keep this general to use at any institution I:
  - Removed a link to UCL-internal courses
  -  Moved the UCL bioimage interest group lower in the list of talks / seminars, and added a link to the GloBIAS seminar series. The UCL seminars are still available to all for online attendance - so still good for it to be in this list.