### PR TITLE
Fix typos found with codespell

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -39,7 +39,7 @@ $ git push origin main
 > - Cancel any "01 Maintain: Build and Deploy Site" workflow currently running
 > - Run the "02 Maintain: Check for Updated Packages" workflow and merge any PR opened to update the renv lockfile
 > - This should automatically run the "03 Maintain: Apply Package Cache" workflow to install packages and build the cache
-> - A successful cache buid should then trigger the "01 Maintain: Build and Deploy Site" workflow
+> - A successful cache build should then trigger the "01 Maintain: Build and Deploy Site" workflow
 
 ### Updating using GitHub
 
@@ -194,7 +194,7 @@ There are no repository variables for this workflow.
 
 ## Pull Request and Review Management
 
-Because our lessons execute code, pull requests are a security risk for any lesson and thus have security measures associted with them.
+Because our lessons execute code, pull requests are a security risk for any lesson and thus have security measures associated with them.
 **Do not merge any pull requests that do not pass checks and do not have bots commented on them.**
 
 This series of workflows all go together and are described in the following diagram and the below sections:
@@ -256,5 +256,5 @@ This emits an artifact that is the pull request number for the next action.
 
 ### Remove Pull Request Branch (pr-post-remove-branch.yaml)
 
-Tiggered by `pr-close-signal.yaml`.
+Triggered by `pr-close-signal.yaml`.
 This removes the temporary branch associated with the pull request (if it was created).

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -39,7 +39,7 @@ $ git push origin main
 > - Cancel any "01 Maintain: Build and Deploy Site" workflow currently running
 > - Run the "02 Maintain: Check for Updated Packages" workflow and merge any PR opened to update the renv lockfile
 > - This should automatically run the "03 Maintain: Apply Package Cache" workflow to install packages and build the cache
-> - A successful cache build should then trigger the "01 Maintain: Build and Deploy Site" workflow
+> - A successful cache buid should then trigger the "01 Maintain: Build and Deploy Site" workflow
 
 ### Updating using GitHub
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -194,7 +194,7 @@ There are no repository variables for this workflow.
 
 ## Pull Request and Review Management
 
-Because our lessons execute code, pull requests are a security risk for any lesson and thus have security measures associated with them.
+Because our lessons execute code, pull requests are a security risk for any lesson and thus have security measures associted with them.
 **Do not merge any pull requests that do not pass checks and do not have bots commented on them.**
 
 This series of workflows all go together and are described in the following diagram and the below sections:
@@ -256,5 +256,5 @@ This emits an artifact that is the pull request number for the next action.
 
 ### Remove Pull Request Branch (pr-post-remove-branch.yaml)
 
-Triggered by `pr-close-signal.yaml`.
+Tiggered by `pr-close-signal.yaml`.
 This removes the temporary branch associated with the pull request (if it was created).

--- a/episodes/choosing-acquisition-settings.md
+++ b/episodes/choosing-acquisition-settings.md
@@ -304,7 +304,7 @@ settings, with figure 5 as a great example of the different trade-offs.
 
 ::::::::::::::::::::::::::::::::::::: challenge 
 
-## Choosing acquisiton settings
+## Choosing acquisition settings
 
 In the previous episode, we used an example of investigating the effects of a 
 specific chemical on cells grown in culture. Continuing with this, which 
@@ -541,7 +541,7 @@ capture the two cells, no matter their alignment with the grid:
 micrometre wide) overlaid by a 5 micrometre pixel grid. 
 Right - the equivalent image with a grayscale colormap" width="80%"}
 
-Failing to meet the Nyquist critera can also result in various image artifacts 
+Failing to meet the Nyquist criteria can also result in various image artifacts 
 known as 'aliasing'. For example, consider the digram below - here we have 6 
 small cells (blue) that are evenly spaced in the x direction. Using a pixel 
 spacing of 10 micrometre, this produces an odd effect in our final image, where 

--- a/episodes/designing-a-light-microscopy-experiment.md
+++ b/episodes/designing-a-light-microscopy-experiment.md
@@ -421,7 +421,7 @@ choosing image processing and statistical analysis methods.
 | :-----                  | :-------            | :------- 
 | Brightfield             | Illuminates the sample with light from one side, and images on the other | Hard to see many biological structures - usually requires contrast agents/staining to increase contrast
 | Phase contrast / DIC    | Makes use of slight changes in the ‘phase’ of light as it passes through a sample to increase contrast | Allows unstained samples to be seen more easily
-| Widefield flourescence  | Fluorescent labels (with specific excitation and emission wavelengths) bind to specific biological structures | Widefield illuminates the whole sample at once, which can lead to blurry images in thicker samples
+| Widefield fluorescence  | Fluorescent labels (with specific excitation and emission wavelengths) bind to specific biological structures | Widefield illuminates the whole sample at once, which can lead to blurry images in thicker samples
 | Laser scanning confocal | A laser is scanned across the sample point by point in a raster pattern | Allows 'optical sectioning', giving clearer images in full 3D. More complex to use than widefield, also slower to acquire images.
 | Spinning disc confocal  | An array of pinholes on a disc split the laser into hundreds of beams that move across the sample | Faster than standard laser scanning confocal
 | Super-resolution        | Wide range of methods that break the classic 'diffraction limit' of light, allowing resolutions down to tens of nanometres | More complex to use than standard widefield / confocal

--- a/episodes/filetypes-and-metadata.md
+++ b/episodes/filetypes-and-metadata.md
@@ -237,7 +237,7 @@ During the [setup instructions](../learners/setup.md), we installed the
 
 If you want to open more types of file, you will have to install the relevant 
 reader following the 
-[intructions in the BioIO docs](https://bioio-devs.github.io/bioio/OVERVIEW.html).
+[instructions in the BioIO docs](https://bioio-devs.github.io/bioio/OVERVIEW.html).
 Note the `bioio-bioformats` reader should allow a wide range of file formats to 
 be read.
 

--- a/episodes/imaging-software.md
+++ b/episodes/imaging-software.md
@@ -86,7 +86,7 @@ Plugins, in contrast to scripts, are focused on adding optional new features to
 a piece of software (rather than automating use of existing features). They 
 allow members of the community, outside the main team that develops the 
 software, to add features they need for a particular image type or processing 
-task. They're designed to be re-useable so other members of the community can 
+task. They're designed to be reusable so other members of the community can 
 easily benefit from these new features.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
@@ -254,7 +254,7 @@ menu-bar of Napari and select:
 
 You should see a fluorescence microscopy image of some cells:
 
-![](fig/cells-napari.png){alt="A screenshot of a flourescence microscopy image 
+![](fig/cells-napari.png){alt="A screenshot of a fluorescence microscopy image 
 of some cells in Napari"}
 
 ## Napari's User interface

--- a/episodes/instance-segmentation-and-measurements.md
+++ b/episodes/instance-segmentation-and-measurements.md
@@ -8,7 +8,7 @@ exercises: 15
 
 - How do we perform instance segmentation in Napari?
 - How do we measure cell size with Napari?
-- How do we save our work to create re-usable workflows?
+- How do we save our work to create reusable workflows?
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
@@ -20,7 +20,7 @@ exercises: 15
 
 - Calculate the number of cells and average cell volume.
 
-- Save and edit your workflow to re-use on subsequent images.
+- Save and edit your workflow to reuse on subsequent images.
 
 - Perform more complex cell shape analysis using scikit-image's `regionprops`.
 
@@ -365,7 +365,7 @@ again.
 viewer.layers.remove('instance_seg')
 
 eroded_semantic_seg = viewer.layers['eroded ball 10'].data
-# Create a new instace segmentation using the eroded mask
+# Create a new instance segmentation using the eroded mask
 instance_seg = label(eroded_semantic_seg)
 
 viewer.add_labels(instance_seg)
@@ -498,7 +498,7 @@ There are 11 individual nuclei
 
 You now have a correct instance segmentation. You could return to
 using the napari-skimage plugin to calculate the sizes
-of each nucleus and export the results to a speadsheet or your preferred
+of each nucleus and export the results to a spreadsheet or your preferred
 analysis software using the `Save Results` function. However you've probably
 picked up enough Python during this course to complete the analysis you need
 with just the Napari console. Let's give it a try. The following commands
@@ -608,7 +608,7 @@ These numbers provide a good quantitative measure of the quantity and
 volume of cell nuclei suitable for an experiment investigating how these
 quantities change over time.
 
-We can save our work from the console for re-use on data from subsequent
+We can save our work from the console for reuse on data from subsequent
 time points, creating a repeatable measurement workflow.
 
 ```python

--- a/episodes/multi-dimensional-images.md
+++ b/episodes/multi-dimensional-images.md
@@ -156,7 +156,7 @@ Next, let's look at a 3D image where an additional (fourth) dimension contains
 data from different 'channels'. Remove the brain image and select:  
 `File > Open Sample > napari builtins > Cells (3D+2Ch)`  
 
-![](fig/cells-napari.png){alt="A screenshot of a flourescence microscopy image 
+![](fig/cells-napari.png){alt="A screenshot of a fluorescence microscopy image 
 of some cells in Napari"}
 
 Image channels can be used to store data from multiple sources for the same 
@@ -178,7 +178,7 @@ This diagram shows an example of a 2D image with channels, but this can also be
 extended to 3D images, as we will see now.
 
 Fluorescence microscopy images, like the one we currently have open in Napari, 
-are common examples of images with multiple channels. In flourescence 
+are common examples of images with multiple channels. In fluorescence 
 microscopy, different 'flourophores' are used that target specific features 
 (like the nucleus or cell membrane) and emit light of different wavelengths. 
 Images are taken filtering for each of these wavelengths in turn, giving one 

--- a/episodes/quality-control-and-manual-segmentation.md
+++ b/episodes/quality-control-and-manual-segmentation.md
@@ -29,7 +29,7 @@ number of cells in an image.
 First, let's open one of Napari's sample images with:  
 `File > Open Sample > napari builtins > Cells (3D + 2Ch)`
 
-![](fig/cells-napari.png){alt="A screenshot of a flourescence microscopy image 
+![](fig/cells-napari.png){alt="A screenshot of a fluorescence microscopy image 
 of some cells in Napari"}
 
 ## Quality control
@@ -623,7 +623,7 @@ These models learn to segment images based on provided 'groundtruth' data. This
 interest. While generating this manual groundtruth is still slow and time 
 consuming, the advantage is that we only need to segment a small subset of our 
 images (rather than the entire thing). Also, once the model is trained, it can 
-be re-used on similar image data.
+be reused on similar image data.
 
 It's worth bearing in mind that automated methods are rarely perfect (whether 
 they're classic image processing, machine learning or deep learning based). It's 


### PR DESCRIPTION
Found a few typos when working on the instance segmentation lesson. 

This PR fixes typos flagged up by running [`codespell`](https://github.com/codespell-project/codespell).